### PR TITLE
Light updates to documentation and required plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ More information about AppInsights API could be found [here](http://azure.micros
 
   * Add the plugin to your project
 
-    <!-- `cordova plugin add ../cordova-plugin-appinsights --variable INSTRUMENTATION_KEY=<your_key>` -->
-    `cordova plugin add ../cordova-plugin-appinsights`
-
+    `cordova plugin add ../cordova-plugin-appinsights --variable INSTRUMENTATION_KEY=<your_key>`
+    
   * Set up intrumentation key for AppInsights API. Modify the following line in `config.xml` file at the project root
 
     `<preference name="instrumentation_key" value="$INSTRUMENTATION_KEY">`
@@ -88,7 +87,7 @@ More information about AppInsights API could be found [here](http://azure.micros
 
   * _optional_: install battery and network status plugins to track their events to AppInsights as well.
 
-    `cordova plugin add org.apache.cordova.battery-status org.apache.cordova.network-information`
+    `cordova plugin add cordova-plugin-battery-status cordova-plugin-network-information`
 
   * Build and run application: `cordova run`.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,11 +17,11 @@
     <repo>https://github.com/MSOpenTech/cordova-plugin-appinsights</repo>
     <issue>https://github.com/MSOpenTech/cordova-plugin-appinsights/issues</issue>
 
-    <dependency id="org.apache.cordova.device" />
+    <dependency id="cordova-plugin-device" />
 
     <!-- FIXME: There is currently a bug in cordova-lib which makes usage of mandatory plugin
     variables impossible. The following line should be uncommented once this bug is fixed -->
-    <!-- <preference name="INSTRUMENTATION_KEY" /> -->
+    <preference name="INSTRUMENTATION_KEY" />
 
     <js-module name="AppInsights" src="www/AppInsights.js">
         <clobbers target="window.appInsights.config"/>
@@ -38,9 +38,9 @@
         <access origin="https://dc.services.visualstudio.com/v2/track" />
     </config-file>
 
-    <!-- <config-file target="../../config.xml" parent="/*">
+    <config-file target="../../config.xml" parent="/*">
         <preference name="instrumentation_key" value="$INSTRUMENTATION_KEY" />
-    </config-file> -->
+    </config-file>
 
     <platform name="android">
     </platform>


### PR DESCRIPTION
Cordova now supports mandatory plugin variables. Uncommented to include
INSTRUMENTATION_KEY during setup

Updated documentation

Updated required cordova plugins as plugin names have changed.